### PR TITLE
Fix v0.15.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test-watch": "./node_modules/.bin/grunt watch 2>&1 >/dev/null & ./node_modules/karma/bin/karma start karma.dev.js",
     "test": "./node_modules/.bin/grunt build && ./node_modules/karma/bin/karma start karma.ci.js"
   },
-  "main": "lib/main.js",
+  "main": "tools/cjs/main.js",
   "directories": {
     "lib": "lib/"
   },


### PR DESCRIPTION
Fixes: https://github.com/react-bootstrap/react-bootstrap/issues/385

Please merge or make necessary changes as we cannot `require('react-bootstrap') with v0.15.0